### PR TITLE
Fix Explorations page title and subtitle

### DIFF
--- a/src/pages/Explorations.vue
+++ b/src/pages/Explorations.vue
@@ -3,7 +3,7 @@
     <HeroBanner
       id="hero"
       title="Explorations"
-      subtitle="UI experiments, design process, and work-in-progress from across projects."
+      subtitle="Process and concept work from across projects."
       as="h1"
     />
 

--- a/src/pages/Explorations.vue
+++ b/src/pages/Explorations.vue
@@ -2,8 +2,8 @@
   <PageWrapper>
     <HeroBanner
       id="hero"
-      title="My Sketchbook"
-      subtitle="Visual explorations, UI experiments, and work-in-progress from across projects."
+      title="Explorations"
+      subtitle="UI experiments, design process, and work-in-progress from across projects."
       as="h1"
     />
 


### PR DESCRIPTION
## Summary
- Fix hero title still showing "My Sketchbook" on the Explorations page
- Update subtitle to "Process and concept work from across projects." (removes restatement of the title)

https://claude.ai/code/session_01HgSbJchaQME6YXxCKEmGEB