### PR TITLE
Add grid/list view toggle to Writing section

### DIFF
--- a/src/components/card/ArticleCard/ArticleCard.vue
+++ b/src/components/card/ArticleCard/ArticleCard.vue
@@ -227,6 +227,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    indexRow: {
+      type: Boolean,
+      default: false,
+    },
     featured: {
       type: Boolean,
       default: false,
@@ -280,6 +284,7 @@ export default {
         'defaultcard--borderless': this.borderless,
         'defaultcard--list': this.list,
         'defaultcard--mobile-list': this.mobileList,
+        'defaultcard--index-row': this.indexRow,
         'defaultcard--featured': this.featured,
         'defaultcard--locked': this.isEffectivelyLocked,
       };
@@ -354,6 +359,28 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@mixin list-row-base {
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  border: none;
+  min-height: auto;
+  border-block-start: var(--border) !important;
+  padding-block: var(--spacing-xs);
+
+  &:hover {
+    background: transparent;
+    box-shadow: none !important;
+  }
+
+  .image {
+    display: none !important;
+  }
+
+  .info {
+    padding: 0 !important;
+  }
+}
+
 * {
   border-radius: 0;
 }
@@ -688,20 +715,11 @@ img {
 }
 .defaultcard--mobile-list {
   @media only screen and (max-width: 767px) {
-    border-radius: 0 !important;
-    box-shadow: none !important;
-    border: none;
+    @include list-row-base;
     padding-block-start: var(--spacing-sm);
     display: grid !important;
     grid-template-columns: repeat(3, 1fr);
     grid-gap: var(--spacing-xs);
-    min-height: auto;
-    border-block-start: var(--border) !important;
-
-    &:hover {
-      background: transparent;
-      box-shadow: none;
-    }
 
     .image {
       grid-column: 3 / 4;
@@ -709,7 +727,6 @@ img {
       margin: 0 !important;
       aspect-ratio: 1 / 1 !important;
       inline-size: 100% !important;
-      display: none !important;
 
       img {
         object-fit: cover;
@@ -728,7 +745,6 @@ img {
     .info {
       grid-column: 1 / 4;
       grid-row: 1;
-      padding: 0 !important;
       display: flex;
       flex-direction: column;
       justify-content: flex-start;
@@ -747,21 +763,57 @@ img {
       width: 100%;
       margin-inline-start: 0;
     }
+  }
+}
 
-    // Hide title and show description (which will contain title content)
-    .textblock--mobile-list :deep(.title) {
-      // display: none !important;
-      // font-size: var(--font-size-sm) !important;
-    }
+.defaultcard--index-row {
+  @include list-row-base;
+  display: flex !important;
+  flex-direction: row;
+  align-items: baseline;
+  grid-column: 1 / -1;
 
-    .textblock--mobile-list :deep(.description) {
-      // margin-block-end: 0;
-      // margin-block-start: 0;
-    }
+  .info {
+    flex: 1;
+  }
 
-    .textblock--mobile-list :deep(.tags) {
-      // margin-block-end: var(--spacing-xxs);
-    }
+  .textblock {
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    flex-wrap: wrap;
+  }
+
+  .textblock :deep(.description) {
+    display: none !important;
+  }
+
+  .textblock :deep(.title) {
+    font-size: var(--font-400);
+    font-weight: var(--fontWeight-medium);
+    line-height: var(--lineHeight-base);
+  }
+
+  .textblock :deep(.title-link:hover .title) {
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+    text-decoration-thickness: 0.15rem;
+  }
+
+  .textblock :deep(.eyebrow) {
+    font-size: var(--font-2xs);
+    color: var(--foreground-muted);
+  }
+
+  .textblock :deep(.tags--content) {
+    margin-block-start: 0;
+    padding-block-start: 0;
+    flex-shrink: 0;
+    align-self: baseline;
+    justify-content: flex-end;
   }
 }
 

--- a/src/pages/MyLibrary.vue
+++ b/src/pages/MyLibrary.vue
@@ -108,24 +108,31 @@
       <!-- No filters: Show sections with headers -->
       <template v-if="!hasActiveFilters">
         <!-- Writing Section -->
-        <TextBlock
-          style="
-            align-items: center;
-            grid-template-columns: repeat(3, 1fr);
-            padding-block-end: var(--spacing-md);
-          "
-          title="Writing"
-          as="h2"
-          description=""
-          class="section-header"
-        />
+        <div class="section-header-row">
+          <TextBlock title="Writing" as="h2" description="" class="section-header" />
+          <div class="view-toggle">
+            <MyButton
+              size="small"
+              :type="viewMode === 'list' ? 'outline' : 'ghost'"
+              label="List"
+              @click="setViewMode('list')"
+            />
+            <MyButton
+              size="small"
+              :type="viewMode === 'grid' ? 'outline' : 'ghost'"
+              label="Grid"
+              @click="setViewMode('grid')"
+            />
+          </div>
+        </div>
         <div v-if="filteredArticlesAndTools.length" class="library-section">
           <GridParent tight class="posts">
             <ArticleCard
               borderless
               v-for="(entry, index) in filteredArticlesAndTools"
               :key="entry.id"
-              :mobileList="index !== 0"
+              :mobileList="viewMode === 'grid' ? index !== 0 : false"
+              :indexRow="viewMode === 'list'"
               :alt="entry.alt"
               :description="entry.description"
               :filename="entry.thumbnail"
@@ -330,6 +337,7 @@ export default {
   data() {
     return {
       library,
+      viewMode: localStorage.getItem('libraryViewMode') || 'grid',
       query: '',
       selectedTypes: ['article', 'tool', 'case-study', 'design-project'],
       selectedTags: [],
@@ -410,6 +418,10 @@ export default {
     },
   },
   methods: {
+    setViewMode(mode) {
+      this.viewMode = mode;
+      localStorage.setItem('libraryViewMode', mode);
+    },
     clearFilters() {
       this.query = '';
       this.selectedTypes = [...this.allTypeValues];
@@ -520,8 +532,22 @@ export default {
   border-block-start: var(--border);
 }
 
-.section-header {
+.section-header-row {
   grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-block-end: var(--spacing-md);
+}
+
+.section-header {
+  grid-column: unset;
+}
+
+.view-toggle {
+  display: flex;
+  gap: var(--spacing-xxs);
+  flex-shrink: 0;
 }
 
 .library-section__header {


### PR DESCRIPTION
## Summary

- Add **List/Grid toggle** to the Writing section header in `/library` — defaults to Grid, persisted in `localStorage`
- In List mode: all writing articles render as compact index rows (title + eyebrow + tags, no image, no description) at all viewport sizes
- In Grid mode: existing full-card behavior restored
- New `indexRow` prop on `ArticleCard` with `.defaultcard--index-row` CSS modifier
- Shared list-row resets extracted into `@mixin list-row-base`; `defaultcard--mobile-list` refactored to use it
- Genie case study: note added about evolution from n8n workflows to native command interface

## Test plan

- [ ] `/library` loads in Grid mode by default
- [ ] Click "List" — Writing articles collapse to compact rows; title + tags visible, no image/description
- [ ] Click "Grid" — Writing articles expand to full cards
- [ ] Refresh — preference is remembered
- [ ] Mobile: List rows stay compact; Grid mode reverts to existing mobile card behavior
- [ ] Case studies and tools sections unaffected by toggle
- [ ] `/doc/designing-genie` — Outcome section includes evolution note

https://claude.ai/code/session_018TCVKKQhtdthoiSN7UKj5Y