### PR TITLE
fix: restore dark-mode --color-highlight so chat inputs/prompts don't inherit accent color

### DIFF
--- a/src/assets/styles/scss/_config.scss
+++ b/src/assets/styles/scss/_config.scss
@@ -411,6 +411,7 @@
   /* Use the RGB values for #fafafa */
   --background: var(--color-offblack);
   --background-accent: var(--color-purple);
+  --color-highlight: hsla(0, 0%, 100%, 0.08);
   --background-darker: var(--color-highlight);
   --link: var(--foreground);
   --border: 1px solid black;
@@ -480,6 +481,7 @@
     /* Use the RGB values for #fafafa */
     --background: var(--color-offblack);
     --background-accent: var(--color-lightyellow);
+    --color-highlight: hsla(0, 0%, 100%, 0.08);
     --background-darker: var(--color-highlight);
     --link: var(--foreground);
     --border: 1px solid black;


### PR DESCRIPTION
--color-highlight was changed to var(--background-accent), which in dark mode
resolves to purple or yellow. Since --background-darker depends on --color-highlight,
this caused chat starter prompt and input backgrounds to render in vivid accent colors.

Override --color-highlight in both dark-theme class and prefers-color-scheme:dark
back to a subtle surface value (hsla white at 8% opacity).

https://claude.ai/code/session_012xnMQdgos6v8hjWsuUhySW