### PR TITLE
Fix lead paragraph size leaking across articles with no h2

### DIFF
--- a/src/assets/styles/scss/typography.scss
+++ b/src/assets/styles/scss/typography.scss
@@ -451,7 +451,7 @@ figcaption {
   }
 }
 
-h1~p {
+h1 + p {
   font-size: var(--font-p-lead);
 }
 


### PR DESCRIPTION
Change h1~p (general sibling) to h1+p (adjacent sibling) so only
the first paragraph after h1 gets the lead font size. Previously,
articles without any h2 had every paragraph enlarged since all p
elements shared the same parent container as h1.

https://claude.ai/code/session_01FQ55WXsfQhUtwW4CwnEXUM