### PR TITLE
Unlock OnLogic, Kum & Go, and Softchoice case studies

### DIFF
--- a/src/assets/data/library.json
+++ b/src/assets/data/library.json
@@ -536,8 +536,7 @@
         "commerce",
         "configurator"
       ],
-      "locked": true,
-      "securedRoute": "/secured/doc/onlogic-commerce-platform"
+      "locked": false
     },
     {
       "id": 53,
@@ -569,8 +568,7 @@
         "loyalty",
         "mobile"
       ],
-      "locked": true,
-      "securedRoute": "/secured/doc/kg-loyalty-platform"
+      "locked": false
     },
     {
       "id": 54,
@@ -602,8 +600,7 @@
         "rebrand",
         "motion-design"
       ],
-      "locked": true,
-      "securedRoute": "/secured/doc/softchoice-rebrand"
+      "locked": false
     },
     {
       "id": 67,


### PR DESCRIPTION
Set locked: false on the three gated Library entries so the public can
access them. Removed the unused securedRoute fields — the /secured/doc
route never actually guarded the content (the public /doc/<slug> route
served the same page), so it was dead data.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018N1Jjhh8VV67Vger4qvV7i