### PR TITLE
Even out mobile list spacing on Home and Library

### DIFF
--- a/src/components/CardRow2.vue
+++ b/src/components/CardRow2.vue
@@ -331,6 +331,15 @@ export default {
 };
 </script>
 <style scoped lang="scss">
+// Mobile list view: the first row opens the list directly under the section
+// header, so it carries no divider (removed on the card) and no top padding —
+// its content sits flush with the header. Scoped to this list view only.
+@media only screen and (max-width: 767px) {
+  .posts--list > :first-child {
+    padding-block-start: 0 !important;
+  }
+}
+
 .scrolling-wrapper {
   overflow-x: scroll;
   overflow-y: hidden;

--- a/src/pages/MyLibrary.vue
+++ b/src/pages/MyLibrary.vue
@@ -615,6 +615,14 @@ export default {
   .posts {
     grid-gap: 0 !important;
   }
+
+  // The first card in a section is a full card (e.g. the featured article),
+  // not a mobile-list row, so it has no bottom padding of its own. With the
+  // grid gap removed above, it would sit flush against the divider of the next
+  // row. Give it matching bottom padding so that divider is evenly spaced.
+  .library-section .posts > *:first-child {
+    padding-block-end: var(--spacing-sm);
+  }
 }
 
 .section-header-row {


### PR DESCRIPTION
## Summary

Evens out the spacing around list-row dividers on **mobile** for the homepage Writing list and the Library card sections, so the gap above and below each divider matches. Desktop list views are unchanged throughout.

## Changes

- **`ArticleCard.vue`**
  - `.defaultcard--mobile-list` uses symmetric `padding-block` so each mobile row is evenly padded above and below its top-border divider.
  - Added a `:first-child` exception so the first mobile row has no divider above it (matching the desktop list variant).
- **`GridParent.vue`** — drop the flex gap on mobile only (`max-width: 767px`) for the homepage list container (`.grid-template--rows.posts--list`). Other `rows` layouts (Studio, Hire, Product, etc.) keep their gap.
- **`MyLibrary.vue`**
  - Drop the card-grid gap on mobile only so the Library stack matches the homepage list. `ImageCard` grids (`WorkIndex`/`PlayIndex`) are unaffected.
  - Give the first card in each section (the full featured card, not a mobile-list row) matching bottom padding on mobile, so it isn't left flush against the next row's divider once the gap is removed.

## Verification

Geometry verified with isolated Chromium renders of the exact token values (top-border divider, `spacing-sm` gap, mobile-list padding, featured card) — before shows the uneven gap / flush featured card, after shows evenly padded, flush rows on both surfaces. The full app wasn't run because dependencies aren't installed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3NoCEkqYak223vXhUe3Ba)_