### PR TITLE
Improve body prose readability: contrast, leading, measure

### DIFF
--- a/src/assets/styles/scss/_config.scss
+++ b/src/assets/styles/scss/_config.scss
@@ -392,6 +392,9 @@
   --lineHeight-short: 1.2;
   --lineHeight-base: 1.4;
   --lineHeight-tall: 1.5;
+  /* Body prose — tighter than --lineHeight-taller so lines read as present,
+     not floaty. Reserve --lineHeight-taller (1.8) for large display copy. */
+  --lineHeight-body: 1.6;
   --lineHeight-taller: 1.8;
 
   /* IMAGE FILTERS */

--- a/src/assets/styles/scss/typography.scss
+++ b/src/assets/styles/scss/typography.scss
@@ -149,8 +149,11 @@ input {
      shrink. Line-height and all other properties left as-is. */
   /* design-guard:ignore */
   font-size: clamp(1.7rem, 1.41rem + 0.76vw, 2rem);
-  line-height: var(--lineHeight-taller);
-  color: rgba(var(--foreground-rgb), 0.75) !important;
+  /* Tighter leading than display copy so prose reads as present, not floaty. */
+  line-height: var(--lineHeight-body);
+  /* Raised from 0.75 → 0.88: full-enough contrast for comfortable reading while
+     staying softer than pure foreground. Captions/.subtle keep the 0.75 tier. */
+  color: rgba(var(--foreground-rgb), 0.88) !important;
   /* design-guard:ignore */
   font-variation-settings:
     'wdth' 102,

--- a/src/components/text/MarkdownRenderer.vue
+++ b/src/components/text/MarkdownRenderer.vue
@@ -945,6 +945,21 @@ export default {
     }
   }
 
+  /* Readable measure — cap prose line length (~64ch) so wide viewports don't
+     produce unreadably long lines. Media-bearing paragraphs, code, tables, and
+     the poster h1 are intentionally left full-width. No effect on mobile, where
+     the viewport is narrower than the cap. */
+  p:not(:has(img)),
+  li,
+  blockquote,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    max-width: var(--size-36);
+  }
+
   a {
     color: var(--color-action);
     font-weight: var(--fontWeight-medium);


### PR DESCRIPTION
Keep the signature editorial system (poster headings, variable-font
axes, Manrope weight/size) intact; fix only the three things that hurt
readability in article body copy:

- Body line-height 1.8 -> 1.6 via new --lineHeight-body token, so prose
  reads as present rather than floaty (display copy keeps 1.8).
- Body text contrast 0.75 -> 0.88 opacity for comfortable reading;
  captions/.subtle keep the 0.75 muted tier.
- Cap prose measure at --size-36 (~64ch) on wide viewports; media
  paragraphs, code, tables, and the poster h1 stay full-width, and mobile
  is unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LWgNMVXtapqtEnsdHTqWpV