### PR TITLE
Align footer name + description with article card TextBlock

### DIFF
--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -27,7 +27,11 @@
           </div>
           <GridParent tight class="outer">
             <div id="maindetails">
-              <TextBlock as="h4" title="Jacques Ramphal" />
+              <TextBlock
+                as="h4"
+                title="Jacques Ramphal"
+                description="I'm a designer working where design, code, and AI meet. Subscribe for writing on what I'm learning there."
+              />
               <div class="footer-subscribe">
                 <SubscribeForm />
               </div>

--- a/src/components/form/SubscribeForm.vue
+++ b/src/components/form/SubscribeForm.vue
@@ -1,7 +1,5 @@
 <template>
   <div class="subscribe">
-    <p class="subscribe__pitch">{{ pitch }}</p>
-
     <form class="subscribe__form" @submit.prevent="subscribe">
       <MyInput
         id="subscribe-email"
@@ -32,10 +30,6 @@
 
 <script setup>
 import { ref } from 'vue';
-
-// The newsletter pitch shown above the field.
-const pitch =
-  "I'm a designer working where design, code, and AI meet. Subscribe for writing on what I'm learning there.";
 
 // Buttondown embed endpoint for the owned list.
 const ENDPOINT = 'https://buttondown.com/api/emails/embed-subscribe/jacquesramphal';
@@ -82,11 +76,6 @@ const subscribe = async () => {
 </script>
 
 <style scoped>
-.subscribe__pitch {
-  margin: 0 0 var(--spacing-xs) 0;
-  color: var(--foreground-muted, var(--foreground));
-}
-
 .subscribe__form {
   width: 100%;
 }


### PR DESCRIPTION
Move the newsletter pitch into the footer's TextBlock as its description
so the author name and description render through the same default
TextBlock used by article cards. The name keeps its bold h4 weight and
the description now sits tightly beneath it (spacing-xs) with default
text styling, instead of being a separate muted paragraph inside the
subscribe form with a larger spacing-md gap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HBuK8KppayAZrqQ7Udqq6d