### PR TITLE
Align footer name + description with article card TextBlock

### DIFF
--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -431,6 +431,13 @@ li {
 }
 
 #maindetails {
+  // Match the article-card title weight. Card titles sit inside a link, so
+  // `a h4 { font-weight: inherit }` pulls them to medium; the footer name isn't
+  // a link, so mirror that weight here instead of the default bold.
+  :deep(.title) {
+    font-weight: var(--fontWeight-medium);
+  }
+
   @media only screen and (min-width: 768px) {
     padding-inline-end: var(--spacing-md);
   }

--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -11,9 +11,10 @@
       <GridContainer>
         <GridParent
           tight
+          class="footer-main"
           style="grid-template-columns: none !important; grid-template-rows: repeat(2, auto)"
         >
-          <div class="">
+          <div class="footer-avatar">
             <!-- Profile Picture -->
             <a href="/resume.html"
               ><img
@@ -403,10 +404,28 @@ $spacing-sm: var(--spacing-sm);
   }
 }
 
+// Own the avatar→text gap explicitly so it matches the article card image→title
+// distance regardless of the grid's responsive row gap.
+.footer-main {
+  row-gap: 0 !important;
+}
+
+.footer-avatar {
+  // Match the article-card image→title distance: the card image carries a
+  // spacing-xs margin below it and the info block adds spacing-sm of padding
+  // above the title (constant across breakpoints).
+  margin-block-end: calc(var(--spacing-xs) + var(--spacing-sm));
+}
+
 .outer {
   grid-template-columns: repeat(1, 1fr);
+  // Restore the row gap removed above, so the space before the footer utility
+  // row is unchanged (mirrors the grid's tight row gap).
+  margin-block-end: var(--spacing-sm);
+
   @media only screen and (min-width: 768px) {
     grid-template-columns: repeat(2, 1fr);
+    margin-block-end: var(--spacing-md);
   }
   @media only screen and (min-width: 1201px) {
     grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
## Summary

Makes the footer author block use the same default `TextBlock` treatment as article cards, for the name **weight**, the description, and the spacing between them.

### Changes

- **`MainFooter.vue`**
  - Moved the newsletter pitch into the footer `TextBlock` as its `description`, so the name and description render through one `TextBlock` (title + description) exactly like an article card. This tucks the description under the name at `spacing-xs` instead of the previous loose `spacing-md` gap.
  - Scoped a medium-weight override to the footer name so it matches article-card title weight (see note below).
- **`SubscribeForm.vue`** — removed the now-duplicated pitch paragraph (markup, const, and styles); the form is now just the email input. `SubscribeForm` is only used inside `MainFooter`, so nothing else is affected.

### Weight note

Article-card titles sit inside a link (`<router-link class="title-link">`), and the global rule `a h4 { font-weight: inherit !important; }` pulls them to **medium (500)**, overriding `.title`'s bold. The footer name isn't a link, so it was rendering one step heavier at **bold (600)**. The scoped override brings the name to the same medium weight as the card titles.

### Result

- Name weight now matches article-card titles (medium).
- Description uses the default `.description` styling, grouped tightly under the name like a card.
- Name → description spacing is `spacing-xs`; description → email input is `spacing-md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBuK8KppayAZrqQ7Udqq6d)_