### PR TITLE
Improve body & card readability: contrast, leading, measure, muted meta

### DIFF
--- a/src/assets/styles/scss/_config.scss
+++ b/src/assets/styles/scss/_config.scss
@@ -393,8 +393,9 @@
   --lineHeight-base: 1.4;
   --lineHeight-tall: 1.5;
   /* Body prose — tighter than --lineHeight-taller so lines read as present,
-     not floaty. Reserve --lineHeight-taller (1.8) for large display copy. */
-  --lineHeight-body: 1.6;
+     not floaty, but looser than default for comfortable long-form reading.
+     Reserve --lineHeight-taller (1.8) for large display copy. */
+  --lineHeight-body: 1.7;
   --lineHeight-taller: 1.8;
 
   /* IMAGE FILTERS */

--- a/src/components/text/TextBlock/TextBlock.vue
+++ b/src/components/text/TextBlock/TextBlock.vue
@@ -46,9 +46,12 @@
       :attrs="{ class: 'description' }"
     />
     <!-- Content tags at bottom -->
+    <!-- `subtle` matches the muted treatment of the eyebrow (p.eyebrow.subtle):
+         the inner <p> keeps body color while .subtle drops opacity to 0.75, so
+         the meta row (date · read time · tags) renders identically muted. -->
     <div
       v-if="shouldShowTags && ((tags && tags.length) || readTime || date || isExternal || complete)"
-      class="tags tags--content"
+      class="tags tags--content subtle"
     >
       <span v-if="isExternal" class="tag-label tag-label--external">
         <p style="font-size: var(--font-2xs)">External &#8599;</p>


### PR DESCRIPTION
Targeted readability pass on article body copy and card meta. Keeps the signature editorial system intact (poster headings, variable-font axes, Manrope weight/size) — only the things that actually hurt legibility change.

## What changed

**Body prose (`typography.scss`, `_config.scss`)**
- **Contrast:** body text opacity `0.75 → 0.88`. The muted 0.75 dropped below comfortable reading contrast and locked in via `!important`. Captions/`.subtle` keep the 0.75 tier — the muted token was **not** changed globally.
- **Leading:** new `--lineHeight-body` token, tuned to `1.7`. Display copy keeps `1.8` (`--lineHeight-taller`). Prose reads present rather than floaty, without feeling cramped.
- **Measure:** article prose (`p`, `li`, `blockquote`, `h2`–`h6`) capped at `--size-36` (~64ch) on wide viewports. Media paragraphs, code, tables, and the poster `h1` stay full-width; mobile is unaffected.

**Card meta (`TextBlock.vue`)**
- The meta row (date · read time · tags) now carries the global `subtle` class — the exact muted treatment the "Featured" eyebrow uses (`p.eyebrow.subtle`). Previously the inner `<p>`'s `!important` body color defeated the `.tag-label` muted color, so meta rendered at full contrast. Reusing `.subtle` makes meta and eyebrow match with no new token and no `!important` war.

## What was deliberately kept
- Body **weight** (500) and **size** (17px→20px fluid) — unchanged per direction.
- All muted tokens (`--foreground-muted`, `--text-muted`, `--foreground-subtle`, `.subtle`) — untouched.
- Editorial heading scale, variable-font axes, and voice.

## Verification
- `design-guard` passes (exit 0); the measure is tokenized (`--size-36`) so it doesn't trip `noHardcodedLengths`.
- Pre-commit hook (design-guard) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWgNMVXtapqtEnsdHTqWpV)_