### PR TITLE
Raise mobile body copy floor from 17px to 18px

### DIFF
--- a/src/assets/styles/scss/typography.scss
+++ b/src/assets/styles/scss/typography.scss
@@ -144,11 +144,11 @@ td,
 label,
 input {
   font-weight: var(--fontWeight-medium) !important;
-  /* Fluid body copy: 2rem (20px) on desktop, scaling down to 1.7rem (17px) on
+  /* Fluid body copy: 2rem (20px) on desktop, scaling down to 1.8rem (18px) on
      mobile. Desktop size is unchanged from var(--font-500); only small screens
      shrink. Line-height and all other properties left as-is. */
   /* design-guard:ignore */
-  font-size: clamp(1.7rem, 1.41rem + 0.76vw, 2rem);
+  font-size: clamp(1.8rem, 1.41rem + 0.76vw, 2rem);
   /* Tighter leading than display copy so prose reads as present, not floaty. */
   line-height: var(--lineHeight-body);
   /* Raised from 0.75 → 0.88: full-enough contrast for comfortable reading while


### PR DESCRIPTION
## Summary

Bumps the lower bound of the global fluid body-copy `clamp()` from `1.7rem` (17px) to `1.8rem` (18px). Desktop stays at `2rem` (20px); only the small-screen floor rises a pixel, and the fluid scaling in between stays smooth.

Applies to `p`, `li`, `blockquote`, `td`, `label`, `input` (the shared body-copy rule in `typography.scss`).

### Context

This follow-up was originally pushed onto `claude/footer-spacing-text-styling-3qaxx2` after PR #267 had already merged, so it's re-based here as a fresh change off the latest `main`. The `main`-side revisions to the same rule (line-height and text-color tiers) are preserved — only the clamp floor and its comment change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBuK8KppayAZrqQ7Udqq6d)_