### PR TITLE
Fix article byline teleport losing a render race

### DIFF
--- a/src/pages/MarkdownPage.vue
+++ b/src/pages/MarkdownPage.vue
@@ -837,11 +837,22 @@ export default {
         }
 
         processedMarkdown.value = cleaned;
-        // Wait for DOM to render, then activate the byline teleport
+        // Activate the byline teleport once its slot is in the DOM.
+        // MarkdownRenderer commits the slot on its own update cycle, so a single
+        // nextTick can fire before the slot exists — and if it does, nothing
+        // re-checks and the byline never renders. Poll across a few animation
+        // frames so the teleport reliably activates regardless of content size.
         bylineReady.value = false;
-        nextTick(() => {
-          bylineReady.value = !!document.getElementById('article-byline-slot');
-        });
+        const activateByline = (attempt = 0) => {
+          if (document.getElementById('article-byline-slot')) {
+            bylineReady.value = true;
+            return;
+          }
+          if (attempt < 60) {
+            requestAnimationFrame(() => activateByline(attempt + 1));
+          }
+        };
+        nextTick(() => activateByline());
         console.log(
           'MarkdownPage: Processed markdown preview:',
           processedMarkdown.value.substring(0, 300)


### PR DESCRIPTION
The byline (author, read time, date) is teleported into a slot injected
after the article <h1>. Activation relied on a single nextTick check of
getElementById('article-byline-slot'), but MarkdownRenderer commits that
slot on its own update cycle. When the check fired before the slot
existed, bylineReady stayed false with nothing to re-check, so the byline
never mounted. This surfaced on the newest article (doc_78, "This Workman
Blames His Tools"), which lost the race deterministically while others
happened to win it.

Poll for the slot across a few animation frames so the teleport activates
reliably regardless of content size.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AZ9AAgjCJfJTzx239VeAiY