### PR TITLE
Combine Play into Labs, add Everything Button + Word Counter, fix lab 404s

### DIFF
--- a/src/components/text/TextBlock/TextBlock.vue
+++ b/src/components/text/TextBlock/TextBlock.vue
@@ -19,7 +19,7 @@
     </div> -->
     <p v-else-if="eyebrow" class="eyebrow subtle">{{ eyebrow }}</p>
     <a
-      v-if="title && titleRoute && isExternalTitleLink"
+      v-if="title && titleRoute && (isExternalTitleLink || isExternal)"
       :href="titleRoute"
       target="_blank"
       rel="noopener noreferrer"


### PR DESCRIPTION
## Summary

Consolidates all playful work under **Labs** (browsable via Library), adds two new Labs entries, and fixes a bug where every lab/game card title 404'd.

## Changes

### Combine Play → Labs
- `/play` was an unlinked, filtered duplicate of Library. It now **redirects to `/library`**; the unused `PlayIndex` import is removed (the component file is left in place).
- The 3 existing experiments (**Scroll-Driven Audio, Editorial Photo Filters, Counter Fill**) were `published: false` and surfaced nowhere. Flipped to `published: true` so they appear under Library's existing **Lab** filter.
- No new menu links — Library is already in the menu.

### New Labs entries
- **The Everything Button** (`/lab/everything-button/`) — a self-contained, clickable scaffold: a plain button that stamps persistent greasy fingerprints on press (wear saved to `localStorage`), long-press to unfold into a hue knob, the Konami code for god mode + confetti, and `hesoyam` to wipe it clean. Respects `prefers-reduced-motion`; the default interaction stays a normal, accessible button. Full ideation lives in `public/lab/everything-button/IDEAS.md`.
- **Unique Word Counter** (`/play/word-counter/`) — its build was never copied into `public/`, so the link was dead. Copied the build in (its assets are hardcoded to that path) so it actually deploys, and added a Labs entry.

### Bug fix — lab/game card titles 404
Lab and game entries use a root-relative `link` (e.g. `/lab/scroll-audio/`) instead of an SPA `route`. `TextBlock` only treated `http(s)://` titles as external, so these titles rendered as a `<router-link>` — which vue-router has no match for, sending every lab card title to the `NotFound` (404) page. The fix honors the card's existing `isExternal` signal so link-based titles render as a real `<a href>` full-page navigation to the static experiment.

## Verification
- All lab/game targets serve **200** as static pages (`/lab/scroll-audio/`, `/lab/photo-filters/`, `/lab/counter-fill/`, `/lab/everything-button/`, `/play/word-counter/`, `/lab/gradient-placeholders/`).
- The Everything Button renders cleanly headless with no console errors; inline JS passes `node --check`.
- No library entry has both a `route` and a `link`, so external `http` articles are unaffected by the TextBlock change.

## Notes
- `library.json` docs/planning: the button's full ideation and the Labs-is-the-home decision are captured in `public/lab/everything-button/IDEAS.md` and `public/lab/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5dVACGejc1WBBXjFZANsB)_