### PR TITLE
Add Featured Lab section (Counter Fill) to homepage

### DIFF
--- a/docs/book-ideas-2026-08.md
+++ b/docs/book-ideas-2026-08.md
@@ -1,0 +1,72 @@
+# Book Ideas — a book people would actually read
+
+_Date: 2026-08-09 · Internal reference_
+
+## Premise
+
+Design books are reference manuals pretending to be books — no stakes, no
+narrative, nothing at risk (Adham's *Practical UI* is a lookup table, not a
+train read). Don't write that book.
+
+**The better book is barely about design.** The distinctive vantage point: a
+craftsperson who built the machine that does his own craft (Genie hands routine
+design/delivery work to code). That's the story every knowledge worker is
+nervously living right now — you're just further down the road.
+
+---
+
+## Direction 1 — "I Automated My Own Job" (narrative nonfiction / tech memoir)
+
+**The one only you can write.** A visual designer works his way into engineering
+over a decade, then builds an agent that absorbs the very work he climbed
+through. Tension: mastery vs. obsolescence, pride vs. letting go, control vs.
+speed.
+
+- Feel: *Soul of a New Machine* (Kidder); Paul Ford's *What Is Code?*
+- Readers: anyone who suspects AI is coming for the interesting parts of their
+  work — i.e. everyone.
+- Why it works: it has a *plot*.
+
+## Direction 2 — "Lost in Handoff" (idea book)
+
+The obsession — the gap between design intent and what ships — as a theory of
+everything. Every transfer loses fidelity: idea→words, plan→execution,
+decision→org, parent→kid. Design handoff is the version you can measure.
+
+- Feel: *Thinking in Systems* (Meadows) — domain as the worked example for a
+  universal law.
+- Readers: managers, writers, anyone who's watched something arrive nothing like
+  it left.
+
+## Direction 3 — "Taste Is the Last Job" (short, punchy argument)
+
+When machines produce infinite competent output for free, the scarce thing is
+judgment — knowing which of ten good options is *right*. A one-sitting manifesto
+on taste, editing, and saying no as the whole job.
+
+- Feel: *Rework* (Fried/Hansson) — short, sharp, read in one sitting.
+- Readers: knowledge workers anxious about AI who want a reason to feel useful.
+- Most commercial of the four.
+
+## Direction 4 — "The Unglamorous Parts" (essay collection)
+
+QA, handoff, the seams, the work nobody demos. A quieter, literary book on
+dignity in the invisible craft.
+
+- Lovely, least commercial, hardest to sell.
+
+---
+
+## Recommendation
+
+**Write #1, and let it carry #2 and #3 inside it.** The memoir is the spine that
+makes people turn pages; each chapter of the story earns a generalizable idea
+(the handoff law, the taste argument) the way good narrative nonfiction always
+does. A book someone reads *because it's about them*, disguised as being about
+you.
+
+## Next step
+
+Spin the strongest direction into a real chapter outline + a two-paragraph pitch
+(shoppable / serializable on the site). Leaning #1 — confirm which vantage feels
+most *true* before building the outline.

--- a/docs/creative-direction-2026-08.md
+++ b/docs/creative-direction-2026-08.md
@@ -1,0 +1,67 @@
+# Creative Direction — Children's Books + Course Material
+
+_Date: 2026-08-09 · Internal reference_
+
+Supersedes the long-form book concepts (`book-ideas-2026-08.md`), which didn't
+land — "meh, I don't know that I'd read those." Two better veins: children's
+books, and course material over long-form design writing.
+
+---
+
+## Vein 1 — Children's books (the real one)
+
+Three concepts (full detail in the uploaded `bookconcepts.md`). They work for the
+reason the essay ideas didn't: stakes and a turn. Each shrinks a professional
+preoccupation to kid-height.
+
+| Concept | Adult theme underneath | Note |
+|---|---|---|
+| **GENIE** | agency when your tools can act for you | most *only-you*, most timely |
+| **FRICTION** | resilience as being *shaped*, not trying harder | safest, most classroom-ready |
+| **THE GAP** | the intent-vs-reality distance (deepest theme) | best story, but *Ish* looms next door |
+
+**Write GENIE first.** It's the most only-you (you built a tool called Genie —
+the book becomes a companion piece to your work), the most timely (kids are
+growing up beside AI helpers; nobody credible is writing the warm, un-scary
+version), and "a wish is what you *ask*" is a genuinely chantable spine.
+
+- **FRICTION** = the safe bet: bedtime-proof, lowest risk.
+- **THE GAP** = best story, hardest to make defensibly new (read *Ish* first).
+
+**Unfair advantage:** wife's classroom = a real room of 5-year-olds, 30-second
+feedback loop. Use her as the test lab. Test the emotional low-point beat first
+(GENIE's flat perfect castle / GAP's put-the-crayon-down).
+
+## Vein 2 — Course material > long-form design writing
+
+Not just a preference — the *correct* format for this knowledge. Adham's book
+works because UI patterns are **reference** knowledge (lookup, static,
+book-shaped). This knowledge is **procedural** — Figma→shipped, handoff, design
+in code, agent orchestration. Procedural knowledge dies in a book and lives in a
+do-along course (reading about swimming vs. getting in the water).
+
+Also: it's coaching **productized** (already mentoring designers toward
+systems/code); it fits the **design-in-code, show-don't-tell** ethos; and it
+builds audience + monetizes far better than essays competing with the whole
+internet.
+
+**Proposed lineup (most-differentiated first):**
+1. **Design in Code** — building UI directly in the browser instead of handing
+   off mockups. The signature move.
+2. **Surviving Handoff** — design decisions that don't die on the way to
+   production. ("The Gap" as a course — more useful than as a book.)
+3. **Building with Agents** — the Genie method: handing routine design/delivery
+   work to code-based workflows while staying in control.
+
+---
+
+## Next-step forks
+
+- **A — GENIE package:** submission-ready manuscript (spread-by-spread text) + a
+  one-page pitch for agents/publishers.
+- **B — Course build:** pick one and produce the full outline, module breakdown,
+  and the "what you'll build" spine. **Recommended start: "Design in Code"** —
+  compounds directly into career + site.
+
+Heart-check pending: if the books are where the heart is, start with GENIE;
+otherwise start with B.

--- a/docs/design-audit-2026-08.md
+++ b/docs/design-audit-2026-08.md
@@ -1,0 +1,114 @@
+# Design Audit — ramphal.design vs. adhamdannaway.com
+
+_Date: 2026-08-09 · Internal reference (not a public site page)_
+
+## Method & caveat
+
+Built from: the ramphal.design **source code** (authoritative for structure,
+copy, and content architecture) plus established knowledge + web search on Adham
+Dannaway's portfolio. The live sites could **not** be loaded during this audit
+(blocked by the network egress proxy), so this does not include a rendered
+pixel-level visual diff. Add screenshots to extend it with a visual layer.
+
+## The two sites in one line each
+
+- **Adham Dannaway:** a *product* — a tightly-focused personal brand engineered
+  to sell one identity ("UI designer + front-end developer") and one thing (the
+  *Practical UI* book). Ruthless minimalism, one idea per screen.
+- **ramphal.design:** a *platform* — a deep, multi-surface site (work, writing,
+  resume, component library, labs/experiments) that shows range but diffuses
+  focus. More ambitious in scope, less resolved in message.
+
+---
+
+## 1. Hero & positioning (his biggest advantage)
+
+- Adham uses the split-face avatar (designer half / dev half) — a visual claim,
+  zero reading required, plus an explicit CTA (portfolio / book).
+- ramphal uses a text headline (*"I design systems and write the code that ships
+  them."*) with a canvas counter-fill animation, and **no hero CTA**
+  (`HeroBanner` supports `label`/`route`/`labeltwo` — unused on the homepage).
+- The ramphal headline is arguably a *sharper* position than his, but it's a
+  visual claim delivered through text only, and it dead-ends into scroll.
+
+**Actions**
+- Add hero CTAs (primary "See selected work" → /library; secondary "Read the
+  writing" or "About").
+- Give the "design + code" claim a visual anchor (token→component demo, code
+  split, or a more central counter-fill moment). Show the duality, don't state it.
+
+## 2. Information architecture & focus
+
+- Adham: ~5 top-level destinations, everything funnels to book + portfolio.
+- ramphal: 17+ page types in source, but nav exposes only **Work** and **Info**.
+  Huge surface area, thin wayfinding. Source shows in-progress signals:
+  `HeroAnimated copy.vue`, `SidebarNav copy.vue`, `UnderConstructionBar`,
+  commented-out blocks.
+
+**Actions**
+- Prune the top level to 3–4 real destinations: **Work · Writing · About · Contact.**
+  Demote Labs/Explorations/Library to secondary.
+- Remove construction signals (`UnderConstructionBar`, `*copy.vue`, dead
+  commented code) before they reach production.
+- Homepage order (Thesis → Select Work → About → Writing) is good; add an
+  explicit **Contact** close.
+
+## 3. Copy & tone
+
+- ramphal's writing is a strength and more distinctive ("the seam between design
+  and engineering", "how decisions survive handoff"). Adham's is cleaner but
+  blander.
+
+**Actions**
+- Keep the voice — don't flatten it to his generic register.
+- Lead About with the one-liner, then the detail (currently two dense blocks).
+- Add social proof: the `TestimonialCarousel.vue` component exists but is unused
+  on the homepage. Add 1–2 real quotes.
+
+## 4. Visual system & craft
+
+- ramphal runs a *more* sophisticated system than his: Style Dictionary tokens,
+  Epilogue + Roboto Flex variable fonts, fluid `clamp()` type, Storybook, GSAP
+  scroll choreography, dark/light theming.
+- Risk is the inverse of his: he under-designs and it reads intentional; ramphal
+  over-builds and some reads unfinished.
+
+**Actions**
+- Audit `!important` out of `typography.scss` — the token cascade is fighting
+  itself, and that's the worst place to leak for a systems-credibility pitch.
+- Rein in scroll-animation count (fadeIn Up/Down/Left/Right + parallax). One or
+  two motion moments beat six; watch for CLS.
+
+---
+
+## Prioritized punch-list
+
+**High impact / low effort**
+1. Add hero CTAs (props already exist).
+2. Add a Contact section/CTA to the homepage close.
+3. Surface `TestimonialCarousel` with 1–2 real quotes.
+4. Remove `UnderConstructionBar` + `*copy.vue` files + dead commented blocks.
+
+**Medium**
+5. Give the hero a visual "design + code" proof, not just text.
+6. Prune top-level nav/IA to 3–4 destinations; demote Labs/Library.
+7. Lead About with the one-liner; tighten the two blocks.
+
+**Ongoing**
+8. Audit `!important` out of the type system.
+9. Rein in scroll animation count.
+
+---
+
+## Net takeaway
+
+Positioning and underlying craft are **stronger** than his — a rarer specialty,
+a real design system, better prose. His site **out-converts** through four
+things: **focus, a visual hook, explicit CTAs, and social proof.** Borrow those;
+keep everything else.
+
+## Sources
+
+- https://www.adhamdannaway.com/
+- https://www.adhamdannaway.com/about
+- https://www.awwwards.com/sites/adham-dannaway-1

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -24,6 +24,38 @@
       :viewAllTo="{ name: 'Library' }"
     />
 
+    <!-- FEATURED LAB — the effect powering the hero headline, shown with a real screenshot -->
+    <AnimatedComponent>
+      <GridContainer id="featured-lab" style="overflow: visible !important">
+        <div
+          class="grid-parent"
+          style="
+            padding-block-end: var(--spacing-md);
+            align-items: center;
+            grid-template-columns: repeat(3, 1fr);
+          "
+        >
+          <TextBlock style="grid-column: 1 / 3" title="Featured Lab" as="h2" description="" />
+          <p class="justify-end" style="align-self: center; white-space: nowrap">
+            <router-link :to="{ name: 'PlayIndex' }">View All</router-link>
+          </p>
+        </div>
+
+        <ImageCard
+          variant="split"
+          size="large"
+          eyebrow="Lab"
+          title="Counter Fill"
+          description="The effect filling this page's headline, live: a script that colours the enclosed counter spaces inside letterforms — built on real DOM text so it stays accessible."
+          filename1="casestudy/counter-fill/counter-fill.png"
+          alt="Counter Fill lab — colouring the enclosed counter spaces inside letterforms"
+          route="/doc/counter-fill"
+          link="/lab/counter-fill/"
+          label="Open the live lab"
+        />
+      </GridContainer>
+    </AnimatedComponent>
+
     <!-- ABOUT SECTION -->
     <AnimatedComponent>
       <TextGrid3


### PR DESCRIPTION
## What

Adds a **Featured Lab** section to the homepage (`src/pages/HomePage.vue`), placed directly after **Select Work**. It spotlights the **Counter Fill** lab — the same effect powering the hero headline — using the real screenshot (`casestudy/counter-fill/counter-fill.png`).

- Image links to the case study (`/doc/counter-fill`)
- CTA (**Open the live lab**) opens the live static demo (`/lab/counter-fill/`)
- **View All** links to the Play index (`PlayIndex` route)

## Why this approach

Built with the existing global `ImageCard` (`variant="split"`, `size="large"`) rather than the generic `CardRow2` lab row. The generic row wouldn't have rendered the image: its desktop branch never passes `filename1`, and it filters out `published: false` entries (all current `type: "lab"` entries are unpublished and carry only `thumbnail`, not `filename*`). The explicit card guarantees the real screenshot renders and both links resolve.

## Verification

`node_modules` isn't installed in this environment, so no build was run. The change uses only verified pieces: globally-registered `ImageCard` / `GridContainer` / `TextBlock`, the confirmed `PlayIndex` route (`/play`) and `/doc/counter-fill` route (doc_69.md), the confirmed image path, and `ImageCard` props that all exist in its declaration (`eyebrow`, `title`, `description`, `filename1`, `alt`, `route`, `link`, `label`, `size`, `variant`). Worth a local `pnpm dev` to eyeball the split/large layout.

## Note on scope

This branch (`claude/ramphal-design-audit-oyk0qv`) also carries three internal reference docs under `docs/` from earlier in the session (design audit, book ideas, creative direction). They're included in this PR since they live on the branch — let me know if you'd prefer the Featured Lab change isolated on its own branch instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnyqP1LgRz8drrtHQickuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnyqP1LgRz8drrtHQickuQ)_