### PR TITLE
Library section headers become mobile accordions

### DIFF
--- a/src/pages/MyLibrary.vue
+++ b/src/pages/MyLibrary.vue
@@ -780,14 +780,14 @@ export default {
     align-items: center;
   }
 
+  // Normalize the header padding to the list-view card rows
+  // (ArticleCard .defaultcard--mobile-list): symmetric spacing-sm around the
+  // divider with no min-height, so a collapsed section header sits on the exact
+  // same vertical rhythm as the cards it toggles.
   .section-header-row--accordion {
+    padding-block: var(--spacing-sm);
+    min-height: 0;
     border-block-end: var(--border);
-  }
-
-  // Collapsed sections only show their header; tighten the padding so the row
-  // reads as a compact accordion header rather than a spaced section title.
-  .section-header-row--accordion.is-collapsed {
-    padding-block-end: var(--spacing-sm);
   }
 }
 

--- a/src/pages/MyLibrary.vue
+++ b/src/pages/MyLibrary.vue
@@ -789,6 +789,15 @@ export default {
     min-height: 0;
     border-block-end: var(--border);
   }
+
+  // The section wrapper's desktop bottom margin (spacing-lg) was leaving large,
+  // uneven gaps between the collapsed accordion rows. Drop it on mobile so every
+  // section header stacks on the same tight, divider-driven rhythm as the
+  // list-view cards; the header's own symmetric padding + border owns the
+  // spacing. Desktop keeps the spacing-lg separation between expanded sections.
+  .library-section {
+    margin-block-end: 0;
+  }
 }
 
 // The desktop list-row styling now lives in ArticleCard's `list` variant


### PR DESCRIPTION
## Summary

On mobile (`< 768px`) the Library section headers — **Writing, Courses, Select Work, Tools & Open Source, Lab** — now collapse into accordion sections, closed by default. Desktop is unchanged: sections are always expanded and no toggle appears.

## What changed (`src/pages/MyLibrary.vue`)

- **Expand/Close text link** on the far right of each header, styled to match the CardRow "View All" link (right-aligned, underlined, foreground color, medium weight, wavy underline on hover).
- **Closed by default** on mobile, each header carrying a **bottom border** so collapsed sections read as divided rows.
- **Padding normalized to the list-view card rows** (`ArticleCard .defaultcard--mobile-list`): symmetric `spacing-sm` block padding with reset `min-height`, so a collapsed section header sits on the same vertical rhythm as the cards it toggles.

## Accessibility & SEO

- The toggle is a real `<button type="button">` with `aria-expanded` and `aria-controls` pointing at each section's content region — keyboard-focusable and screen-reader-announced.
- Content collapses via `v-show` (not `v-if`), so it stays in the DOM and remains in the prerendered HTML (`scripts/prerender.mjs`) — crawlers still see everything.

## Testing

- `vue-cli-service build` completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfdCnfNDeRJJB8QZ2t1ygx)_