### PR TITLE
Add mobile sticky section bar with expandable page nav

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,7 @@ transform: rotate(90deg);
     >
       <!-- menu button hidden: Library link in HeaderNav handles primary nav -->
     </HeaderNav>
+    <SectionStickyBar v-if="!$route.meta.hideNav && !menuOpen" :sections="stickySections" />
     <!-- <ThemeButton v-if="!$route.meta.hideThemeButton" /> -->
     <transition name="fade">
       <component :is="Component" :key="$route.path" />
@@ -89,6 +90,7 @@ import MyButton from './components/Button/Button.vue';
 import FullscreenMenu from './components/FullscreenMenu.vue';
 import StickyNav from './components/StickyNav.vue';
 import HeaderNav from './components/HeaderNav/HeaderNav.vue';
+import SectionStickyBar from './components/SectionStickyBar.vue';
 import MainFooter from './components/MainFooter.vue';
 import TextLink from './components/text/TextLink.vue';
 import MobileTOCBar from './components/MobileTOCBar.vue';
@@ -100,12 +102,13 @@ import SidebarNav from './components/SidebarNav.vue';
 import CustomChatUI from './components/CustomChatUI.vue';
 // import UnderConstructionBar from './components/UnderConstructionBar.vue';
 import { useRouter } from 'vue-router'; // Import Vue Router
-import { provide, ref } from 'vue';
+import { provide, ref, computed } from 'vue';
 export default {
   name: 'App',
   components: {
     StickyNav,
     HeaderNav,
+    SectionStickyBar,
     MainFooter,
     TextLink,
     MobileTOCBar,
@@ -121,8 +124,13 @@ export default {
     // UnderConstructionBar,
   },
   setup() {
+    const router = useRouter();
     const markdownHeadings = ref([]);
     const markdownActiveHeading = ref(null);
+    // Section list fed by non-markdown pages (e.g. the Library) for the mobile
+    // sticky section bar. Kept separate from markdownHeadings so each source
+    // owns its own lifecycle.
+    const librarySections = ref([]);
 
     // Provide functions for markdown pages to update headings
     const updateMarkdownHeadings = (headings) => {
@@ -133,12 +141,31 @@ export default {
       markdownActiveHeading.value = activeHeading;
     };
 
+    const updateLibrarySections = (sections) => {
+      librarySections.value = Array.isArray(sections) ? sections : [];
+    };
+
     provide('updateMarkdownHeadings', updateMarkdownHeadings);
     provide('updateMarkdownActiveHeading', updateMarkdownActiveHeading);
+    provide('updateLibrarySections', updateLibrarySections);
+
+    // Sections shown in the mobile sticky bar, chosen by route: the Library
+    // feeds its own section headers; article/doc pages reuse the markdown H2s.
+    const stickySections = computed(() => {
+      const path = router.currentRoute.value.path || '';
+      if (path.startsWith('/library')) {
+        return librarySections.value || [];
+      }
+      return (markdownHeadings.value || [])
+        .filter((h) => h.level === 2 && h.slug && h.title)
+        .map((h) => ({ id: h.slug, title: h.title }));
+    });
 
     return {
       markdownHeadings,
       markdownActiveHeading,
+      librarySections,
+      stickySections,
     };
   },
   data() {
@@ -164,6 +191,11 @@ export default {
       if (!to.path.startsWith('/doc/')) {
         this.markdownHeadings = [];
         this.markdownActiveHeading = null;
+      }
+      // Clear library-fed sections when leaving the Library so the sticky bar
+      // doesn't carry stale entries onto the next page.
+      if (!to.path.startsWith('/library')) {
+        this.librarySections = [];
       }
     });
   },

--- a/src/components/SectionStickyBar.vue
+++ b/src/components/SectionStickyBar.vue
@@ -1,0 +1,305 @@
+<template>
+  <!--
+    Mobile sticky "on this page" bar. Shows the current section as you scroll
+    past the first heading, and expands downward into the full list of the
+    page's section headers (like a compact fullscreen nav) so you can jump
+    around without scrolling back up. Driven by a plain [{ id, title }] list, so
+    it works for both the Library section headers and an article's markdown
+    body headings. Hidden on desktop, where the TOC sidebar / view toggle
+    already covers this.
+  -->
+  <div v-if="sections.length" class="section-sticky" :class="{ 'section-sticky--visible': visible }">
+    <div v-show="expanded" class="section-sticky__backdrop" @click="close"></div>
+
+    <div class="section-sticky__bar">
+      <button
+        type="button"
+        class="section-sticky__toggle"
+        :aria-expanded="expanded ? 'true' : 'false'"
+        aria-controls="section-sticky-panel"
+        @click="toggle"
+      >
+        <span class="section-sticky__label">{{ currentTitle }}</span>
+        <span
+          class="section-sticky__icon"
+          :class="{ 'section-sticky__icon--open': expanded }"
+          aria-hidden="true"
+        ></span>
+        <span class="section-sticky__sr">{{ expanded ? 'Hide' : 'Show' }} page sections</span>
+      </button>
+
+      <nav
+        v-show="expanded"
+        id="section-sticky-panel"
+        class="section-sticky__panel"
+        aria-label="On this page"
+      >
+        <ul class="section-sticky__list">
+          <li v-for="s in sections" :key="s.id">
+            <button
+              type="button"
+              class="section-sticky__link"
+              :class="{ 'section-sticky__link--active': s.id === currentId }"
+              @click="go(s.id)"
+            >
+              {{ s.title }}
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</template>
+
+<script>
+// Distance below the top of the viewport at which a heading is considered the
+// "current" section. Roughly the height of the sticky bar so the active title
+// flips as each heading tucks under the bar.
+const THRESHOLD = 72;
+
+export default {
+  name: 'SectionStickyBar',
+  props: {
+    // Ordered list of { id, title }. `id` must match a DOM element id on the page.
+    sections: {
+      type: Array,
+      default: () => [],
+    },
+    // Space left above a heading when jumping to it (accounts for the bar).
+    scrollOffset: {
+      type: Number,
+      default: 72,
+    },
+  },
+  data() {
+    return {
+      expanded: false,
+      currentId: null,
+      atTop: true,
+      pastFirst: false,
+      ticking: false,
+    };
+  },
+  computed: {
+    visible() {
+      return this.sections.length > 0 && this.pastFirst && !this.atTop;
+    },
+    currentTitle() {
+      const found = this.sections.find((s) => s.id === this.currentId);
+      return (found && found.title) || (this.sections[0] && this.sections[0].title) || '';
+    },
+  },
+  watch: {
+    sections() {
+      this.$nextTick(this.recompute);
+    },
+    $route() {
+      this.expanded = false;
+      this.$nextTick(this.recompute);
+    },
+  },
+  mounted() {
+    window.addEventListener('scroll', this.onScroll, { passive: true });
+    window.addEventListener('resize', this.onScroll, { passive: true });
+    this.$nextTick(this.recompute);
+  },
+  beforeUnmount() {
+    window.removeEventListener('scroll', this.onScroll);
+    window.removeEventListener('resize', this.onScroll);
+  },
+  methods: {
+    onScroll() {
+      if (this.ticking) return;
+      this.ticking = true;
+      window.requestAnimationFrame(() => {
+        this.recompute();
+        this.ticking = false;
+      });
+    },
+    recompute() {
+      const y = window.scrollY || window.pageYOffset || 0;
+      this.atTop = y < 8;
+      if (this.atTop && this.expanded) this.expanded = false;
+
+      const first = this.sections
+        .map((s) => document.getElementById(s.id))
+        .find((el) => el);
+      if (!first) {
+        this.pastFirst = false;
+        return;
+      }
+
+      const firstTop = first.getBoundingClientRect().top + y;
+      this.pastFirst = y + THRESHOLD >= firstTop;
+
+      // Current section = the last heading whose top has scrolled to/above the
+      // threshold line. Headings are in document order, so once one drops below
+      // the line every later one does too.
+      let current = null;
+      for (const s of this.sections) {
+        const el = document.getElementById(s.id);
+        if (!el) continue;
+        if (el.getBoundingClientRect().top <= THRESHOLD) {
+          current = s.id;
+        } else {
+          break;
+        }
+      }
+      this.currentId = current || (first && first.id) || null;
+    },
+    toggle() {
+      this.expanded = !this.expanded;
+    },
+    close() {
+      this.expanded = false;
+    },
+    go(id) {
+      this.expanded = false;
+      const el = document.getElementById(id);
+      if (!el) return;
+      const y =
+        el.getBoundingClientRect().top +
+        (window.scrollY || window.pageYOffset || 0) -
+        this.scrollOffset;
+      window.scrollTo({ top: Math.max(0, y), behavior: 'smooth' });
+      if (window.history && window.history.pushState) {
+        window.history.pushState(null, '', `#${id}`);
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+// Mobile-only: desktop already has the TOC sidebar (articles) and the view
+// toggle (library), so the compact bar would be redundant there.
+.section-sticky {
+  @media only screen and (min-width: 768px) {
+    display: none;
+  }
+}
+
+.section-sticky__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 99988;
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.section-sticky__bar {
+  position: fixed;
+  inset-block-start: 0;
+  inset-inline: 0;
+  z-index: 99990;
+  display: flex;
+  flex-direction: column;
+  background: var(--background);
+  border-block-end: var(--border);
+  transform: translateY(-100%);
+  transition: transform 0.3s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.section-sticky--visible .section-sticky__bar {
+  transform: translateY(0);
+}
+
+.section-sticky__toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  inline-size: 100%;
+  margin: 0;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  color: var(--foreground);
+  text-align: start;
+}
+
+.section-sticky__label {
+  min-inline-size: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: var(--font-400);
+  font-weight: var(--fontWeight-medium);
+}
+
+// Plus / minus icon, matching the disclosure glyph used elsewhere (markdown
+// <summary>). currentColor + mask keeps it theme-aware.
+.section-sticky__icon {
+  flex-shrink: 0;
+  inline-size: 18px;
+  block-size: 18px;
+  background-color: currentColor;
+  mask-image: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 3.5V12.5M3.5 8H12.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M8 3.5V12.5M3.5 8H12.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-position: center;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+}
+
+.section-sticky__icon--open {
+  mask-image: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.5 8H12.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.5 8H12.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>');
+}
+
+.section-sticky__sr {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.section-sticky__panel {
+  max-block-size: 70vh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  border-block-start: var(--border);
+}
+
+.section-sticky__list {
+  list-style: none;
+  margin: 0;
+  padding: var(--spacing-xxs) 0;
+}
+
+.section-sticky__link {
+  display: block;
+  inline-size: 100%;
+  margin: 0;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--font-400);
+  color: var(--foreground-subtle);
+  text-align: start;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:hover {
+    background: var(--background-darker);
+    color: var(--foreground);
+  }
+}
+
+.section-sticky__link--active {
+  color: var(--foreground);
+  font-weight: var(--fontWeight-medium);
+  background: var(--background-darker);
+}
+</style>

--- a/src/pages/MyLibrary.vue
+++ b/src/pages/MyLibrary.vue
@@ -85,6 +85,7 @@
       <!-- No filters: sectioned view -->
       <template v-if="!hasActiveFilters">
         <div
+          id="library-heading-writing"
           class="section-header-row section-header-row--accordion"
           :class="{ 'is-collapsed': !isSectionOpen('writing') }"
         >
@@ -153,6 +154,7 @@
         </div>
         <div v-if="filteredCourses.length" class="library-section">
           <div
+            id="library-heading-courses"
             class="section-header-row section-header-row--accordion"
             :class="{ 'is-collapsed': !isSectionOpen('courses') }"
           >
@@ -202,6 +204,7 @@
         </div>
         <div v-if="filteredCaseStudiesAndProjects.length" class="library-section">
           <div
+            id="library-heading-work"
             class="section-header-row section-header-row--accordion"
             :class="{ 'is-collapsed': !isSectionOpen('work') }"
           >
@@ -256,6 +259,7 @@
         </div>
         <div v-if="filteredTools.length" class="library-section">
           <div
+            id="library-heading-tools"
             class="section-header-row section-header-row--accordion"
             :class="{ 'is-collapsed': !isSectionOpen('tools') }"
           >
@@ -305,6 +309,7 @@
         </div>
         <div v-if="filteredLabs.length" class="library-section">
           <div
+            id="library-heading-lab"
             class="section-header-row section-header-row--accordion"
             :class="{ 'is-collapsed': !isSectionOpen('lab') }"
           >
@@ -443,6 +448,11 @@ export default {
     TextBlock,
   },
   props: {},
+  // Feed the mobile sticky section bar (rendered globally in App.vue). Falls back
+  // to a no-op when the provider isn't present.
+  inject: {
+    updateLibrarySections: { default: () => () => {} },
+  },
   data() {
     return {
       library,
@@ -561,6 +571,30 @@ export default {
       this.selectedTags.forEach((t) => labels.push(t));
       return labels;
     },
+    // Ordered list of the section headers currently on the page, for the mobile
+    // sticky bar. Ids match the header rows' DOM ids. Only the unfiltered,
+    // sectioned view has multiple sections worth navigating; the filtered
+    // results view is a single list, so the bar stays empty there.
+    librarySectionList() {
+      if (this.hasActiveFilters) return [];
+      const list = [{ id: 'library-heading-writing', title: 'Writing' }];
+      if (this.filteredCourses.length)
+        list.push({ id: 'library-heading-courses', title: 'Courses' });
+      if (this.filteredCaseStudiesAndProjects.length)
+        list.push({ id: 'library-heading-work', title: 'Select Work' });
+      if (this.filteredTools.length)
+        list.push({ id: 'library-heading-tools', title: 'Tools & Open Source' });
+      if (this.filteredLabs.length) list.push({ id: 'library-heading-lab', title: 'Lab' });
+      return list;
+    },
+  },
+  watch: {
+    librarySectionList: {
+      immediate: true,
+      handler(list) {
+        this.updateLibrarySections(list);
+      },
+    },
   },
   mounted() {
     this.onResize();
@@ -568,6 +602,8 @@ export default {
   },
   beforeUnmount() {
     window.removeEventListener('resize', this.onResize);
+    // Prevent the bar from carrying stale library sections after unmount.
+    this.updateLibrarySections([]);
   },
   methods: {
     onResize() {


### PR DESCRIPTION
## Summary

Adds a mobile **sticky section bar** — a compact "on this page" utility bar that appears once you scroll past the first section header. It shows the **current section** in small text with a **plus/minus icon on the right**, and tapping it **expands downward into the full list** of the page's section headers (a compact on-this-page nav). Selecting one jumps to that section and collapses the bar. It hides at the very top of the page, and on desktop (where the article TOC sidebar and the Library view toggle already cover this).

Works on two surfaces from one component:
- **Library** (`/library`): the section headers — Writing, Courses, Select Work, Tools & Open Source, Lab.
- **Articles** (`/doc/*`): the markdown body's H2 headings.

## Changes

- **`src/components/SectionStickyBar.vue`** (new): self-contained, mobile-only bar. Scroll-spy picks the current section; the bar slides in when scrolled past the first heading; expand shows a scrollable list with the active item highlighted and a backdrop to dismiss. Driven by a plain `[{ id, title }]` list.
- **`src/App.vue`**: renders the bar globally and computes its `sections` per route — Library sections via a new `updateLibrarySections` provide/inject, article pages via the existing `markdownHeadings` pipeline. Clears library sections when navigating away.
- **`src/pages/MyLibrary.vue`**: adds stable ids to the section header rows and feeds the current, present sections (respecting which have entries) to the bar.

## Accessibility & SEO

- Toggle is a real `<button>` with `aria-expanded` / `aria-controls`; the panel is a labelled `<nav>`; a backdrop dismisses it.
- No content is moved or hidden — jump targets are the existing headings, so it's SEO-neutral.

## Testing

- `vue-cli-service build` and `lint` both pass.
- Verified in a headless mobile viewport (390×780):
  - Library: bar hidden at top, appears on scroll, expands to all 5 sections (active highlighted), jumping to "Tools" scrolls it to the offset; no JS errors.
  - Article (`/doc/info`): bar shows the current H2 ("What I care about") with all 5 headings listed; no JS errors.

## Note

The bar sits just below the auto-hiding `HeaderNav` (which shows on scroll-up, hides on scroll-down). If you'd prefer the section bar to always sit *above* the header, that's a small z-index/coordination follow-up — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfdCnfNDeRJJB8QZ2t1ygx)_