### PR TITLE
Hide Featured Lab section on home page

### DIFF
--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -25,6 +25,7 @@
     />
 
     <!-- FEATURED LAB — the effect powering the hero headline, shown with a real screenshot -->
+    <!-- Temporarily hidden
     <AnimatedComponent>
       <GridContainer id="featured-lab" style="overflow: visible !important">
         <div
@@ -55,6 +56,7 @@
         />
       </GridContainer>
     </AnimatedComponent>
+    -->
 
     <!-- ABOUT SECTION -->
     <AnimatedComponent>


### PR DESCRIPTION
Comment out the Featured Lab (Counter Fill) block on the home page so it
no longer renders. The hero headline counter-fill effect is unaffected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AqFXUqjf2ngXjAiShriucM