### PR TITLE
Feature Counter Fill in library and clean up Open Source section

### DIFF
--- a/src/assets/data/library.json
+++ b/src/assets/data/library.json
@@ -728,6 +728,7 @@
       "id": 78,
       "type": "lab",
       "published": true,
+      "featured": true,
       "date": "",
       "title": "Counter Fill",
       "eyebrow": "Lab",

--- a/src/pages/MyLibrary.vue
+++ b/src/pages/MyLibrary.vue
@@ -259,7 +259,7 @@
             class="section-header-row section-header-row--accordion"
             :class="{ 'is-collapsed': !isSectionOpen('tools') }"
           >
-            <TextBlock title="Tools & Open Source" as="h2" description="" class="section-header" />
+            <TextBlock title="Open Source" as="h2" description="" class="section-header" />
             <div class="section-header-actions">
               <button
                 type="button"
@@ -535,7 +535,9 @@ export default {
         .sort((a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 : 0));
     },
     filteredLabs() {
-      return this.filteredEntries.filter((e) => e.type === 'lab');
+      return this.filteredEntries
+        .filter((e) => e.type === 'lab')
+        .sort((a, b) => (b.featured ? 1 : 0) - (a.featured ? 1 : 0));
     },
     hasActiveFilters() {
       return (


### PR DESCRIPTION
## Summary

Promotes Counter Fill across the library and tidies section presentation.

- **Article:** Moved the Counter Fill cover image to the top of the article (directly under the title/intro in `doc_69.md`) and removed the duplicate copy that appeared mid-article.
- **Open Source (tool) section:** Flagged the Counter Fill entry as `featured` so it sorts first and renders as the full featured card.
- **Lab section:** Sorted labs by the `featured` flag (consistent with the other sections) and marked the Counter Fill lab as `featured`, so it now leads the Lab section.
- **Section heading:** Renamed **Tools & Open Source** → **Open Source**.

## Changes

- `src/assets/content/doc_69.md` — image moved to top, duplicate removed
- `src/assets/data/library.json` — `featured: true` on the Counter Fill tool and lab entries
- `src/pages/MyLibrary.vue` — sort `filteredLabs` by `featured`; rename section heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gp5QBfoJyLsbgVDAdEEAJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gp5QBfoJyLsbgVDAdEEAJ)_