### PR TITLE
Remove Featured Lab card from home page

### DIFF
--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -24,39 +24,7 @@
       :viewAllTo="{ name: 'Library' }"
     />
 
-    <!-- FEATURED LAB — the effect powering the hero headline, shown with a real screenshot -->
-    <!-- Temporarily hidden
-    <AnimatedComponent>
-      <GridContainer id="featured-lab" style="overflow: visible !important">
-        <div
-          class="grid-parent"
-          style="
-            padding-block-end: var(--spacing-md);
-            align-items: center;
-            grid-template-columns: repeat(3, 1fr);
-          "
-        >
-          <TextBlock style="grid-column: 1 / 3" title="Featured Lab" as="h2" description="" />
-          <p class="justify-end" style="align-self: center; white-space: nowrap">
-            <router-link :to="{ name: 'PlayIndex' }">View All</router-link>
-          </p>
-        </div>
-
-        <ImageCard
-          variant="split"
-          size="large"
-          eyebrow="Lab"
-          title="Counter Fill"
-          description="The effect filling this page's headline, live: a script that colours the enclosed counter spaces inside letterforms — built on real DOM text so it stays accessible."
-          filename1="casestudy/counter-fill/counter-fill.png"
-          alt="Counter Fill lab — colouring the enclosed counter spaces inside letterforms"
-          route="/doc/counter-fill"
-          link="/lab/counter-fill/"
-          label="Open the live lab"
-        />
-      </GridContainer>
-    </AnimatedComponent>
-    -->
+    <!-- FEATURED LAB section removed — see git history to restore -->
 
     <!-- ABOUT SECTION -->
     <AnimatedComponent>


### PR DESCRIPTION
## Summary

Removes the **Featured Lab** (Counter Fill) card from the home page — the standalone card that was rendering just before the About section.

## Why the previous change didn't work

PR #282 wrapped the block in an HTML comment. But the block contains CSS custom properties like `var(--spacing-md)`, and a double hyphen (`--`) is invalid inside an HTML comment. Vue's template parser closed the comment early at the first `--`, so part of the card was re-parsed as live template and the Counter Fill card kept showing on its own.

## Fix

Delete the Featured Lab block outright rather than commenting it out. The block's markup is preserved in git history if it ever needs to be restored.

## Not affected

The hero headline's counter-fill animation is untouched — the `CounterFill` import and its `mounted()` initialization remain in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqFXUqjf2ngXjAiShriucM)_