### PR TITLE
Tighten footer avatar→name gap to match article card

### DIFF
--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -461,9 +461,10 @@ li {
 #maindetails {
   // Match the article-card title weight. Card titles sit inside a link, so
   // `a h4 { font-weight: inherit }` pulls them to medium; the footer name isn't
-  // a link, so mirror that weight here instead of the default bold.
+  // a link, so mirror that weight here. `!important` is required to beat the
+  // global `h4 { font-weight: bold !important }`, which otherwise forces bold.
   :deep(.title) {
-    font-weight: var(--fontWeight-medium);
+    font-weight: var(--fontWeight-medium) !important;
   }
 
   @media only screen and (min-width: 768px) {

--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -411,10 +411,19 @@ $spacing-sm: var(--spacing-sm);
 }
 
 .footer-avatar {
-  // Match the article-card image→title distance: the card image carries a
-  // spacing-xs margin below it and the info block adds spacing-sm of padding
-  // above the title (constant across breakpoints).
-  margin-block-end: calc(var(--spacing-xs) + var(--spacing-sm));
+  // Match the article-card image→title distance. The cards on the site are
+  // `borderless`, whose image carries no margin, so the whole gap is just the
+  // info block's top padding — spacing-sm, which renders consistently across
+  // breakpoints.
+  margin-block-end: var(--spacing-sm);
+
+  // The avatar is an inline <img>, which leaves a few px of baseline descender
+  // below it. Pin it to the line-box bottom so the gap equals the margin
+  // exactly (the card image is object-fit cover with no descender). Kept inline
+  // rather than block so its horizontal alignment is unchanged.
+  #avatar {
+    vertical-align: bottom;
+  }
 }
 
 .outer {


### PR DESCRIPTION
The footer avatar sat ~45px above the name (spacing-xs + spacing-sm
margin, plus the inline image's baseline descender) — nearly double the
real image→title distance on the site's article cards. Those cards are
borderless, so their image has no margin and the whole gap is just the
info block's top padding (spacing-sm, 24px).

Match that: set the avatar margin to spacing-sm and pin the image to the
line-box bottom so the descender no longer pads the gap. Verified at
mobile/tablet/desktop the avatar→name gap now equals the card's
image→title gap (24px), the avatar keeps its left alignment, and the
downstream footer gaps are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Skjx1VuiiCHep7HfUCMCWA