### PR TITLE
Park the subscribe bar above the footer (mobile overflow)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -52,9 +52,11 @@ transform: rotate(90deg);
         />
       </template>
     </StickyNav> -->
-    <GridContainer full v-if="showSubscribeBar" class="article-outro-band">
+    <!-- Subscribe bar parked for now (mobile overflow / radius still to fix).
+         Uncomment to re-enable above the footer on writing articles. -->
+    <!-- <GridContainer full v-if="showSubscribeBar" class="article-outro-band">
       <ArticleOutro />
-    </GridContainer>
+    </GridContainer> -->
     <MainFooter v-if="!$route.meta.hideFooter" />
     <!-- <SimpleFooter v-if="!$route.meta.hideFooter" /> -->
     <!-- <UnderConstructionBar /> -->
@@ -95,7 +97,8 @@ import StickyNav from './components/StickyNav.vue';
 import HeaderNav from './components/HeaderNav/HeaderNav.vue';
 import SectionStickyBar from './components/SectionStickyBar.vue';
 import MainFooter from './components/MainFooter.vue';
-import ArticleOutro from './components/blog/ArticleOutro.vue';
+// ArticleOutro subscribe bar parked for now — see commented block in template.
+// import ArticleOutro from './components/blog/ArticleOutro.vue';
 import TextLink from './components/text/TextLink.vue';
 import MobileTOCBar from './components/MobileTOCBar.vue';
 import SimpleFooter from './components/SimpleFooter.vue';
@@ -114,7 +117,7 @@ export default {
     HeaderNav,
     SectionStickyBar,
     MainFooter,
-    ArticleOutro,
+    // ArticleOutro,
     TextLink,
     MobileTOCBar,
     SimpleFooter,

--- a/src/components/blog/ArticleOutro.vue
+++ b/src/components/blog/ArticleOutro.vue
@@ -115,6 +115,11 @@ const subscribe = async () => {
   padding: var(--spacing-md);
   background: var(--background-darker);
   border-radius: var(--spacing-xs);
+
+  /* Full-bleed on mobile — no rounded corners at the viewport edges. */
+  @media only screen and (max-width: 767px) {
+    border-radius: 0;
+  }
 }
 
 /* CardRow-style header: title/text left, action (the form) right. Stacks on


### PR DESCRIPTION
## Summary

#289 merged at a commit where the subscribe bar was still **active** — my "park" commit landed on the branch *after* the merge, so it never reached `main`. As a result the CTA bar is still rendering above the footer (with the mobile overflow bug where the title/input clip past the viewport edge).

This PR applies that parking to `main`.

## Changes
- **Comment out** the subscribe bar render in `App.vue` (the `<GridContainer full v-if="showSubscribeBar">…</GridContainer>` block) plus its `ArticleOutro` import and registration, so nothing renders and lint stays clean. Kept as comments — uncomment to re-enable.
- Add a `max-width: 767px` rule zeroing the bar's radius (full-bleed, square corners on mobile) so it's ready when re-enabled.

Everything else from #289 stays as merged (frontmatter fix, in-article bar removal, footer text/form changes).

## Verified
`vue-cli-service lint` clean and `vue-cli-service build` compiles green.

## Note
The bar's mobile **overflow** (title + input clipped past the right edge) is a real layout bug, not just the radius. It's parked for now; when you want it back, that overflow needs a proper fix (likely `min-width: 0` / `max-width: 100%` / box-sizing constraints on the intro + form), not just the corners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6RFND9UN3EfV3Yuh22Mco)_