### PR TITLE
Chat: always-visible icon FAB + "Rambot" title bar

### DIFF
--- a/src/components/CustomChatUI.vue
+++ b/src/components/CustomChatUI.vue
@@ -1251,19 +1251,10 @@ export default {
 }
 
 .chat-header-title {
+  /* No type overrides — it's a plain <p>, so it inherits the global body/<p>
+     tokens (same size as the nav wordmark and nav links). */
   margin: 0;
   padding: 0;
-  /* Match the regular nav wordmark: body/link type tokens, not an h5. Keeps the
-     title from rendering at the larger heading size (wider width axis / higher
-     optical size) it had as an <h5>. */
-  font-size: var(--font-500);
-  font-weight: var(--fontWeight-medium);
-  line-height: var(--lineHeight-normal);
-  letter-spacing: var(--letterSpacing-base);
-  font-variation-settings:
-    'wdth' 102,
-    'opsz' 14;
-  color: var(--foreground) !important;
 }
 
 .chat-nav-links {


### PR DESCRIPTION
## Summary

Reworks the chat widget's entry point and open-state title bar (`src/components/CustomChatUI.vue`).

### CTA button
- Reverted to the single **always-visible icon FAB** (chat bubble) on every breakpoint — the same treatment desktop already used.
- Commented out (not deleted) the mobile text CTA ("Ask about Jacques' work") and all of its scroll-driven show/hide machinery: the `mobileButtonVisible` computed, the `handleMobileScroll` handler + its scroll listener/teardown, the `buttonStyle` mobile early-return, and the mobile-CTA CSS block (including the old safeguard that hid the FAB below 768px).

### Title bar
- Renamed the open-chat title from "Ask about Jacques' work" to **"Rambot"**.
- Changed the element from `<h5 class="subtle">` to a plain `<p>` so the title inherits the global body/`<p>` type tokens — matching the nav wordmark and nav links instead of rendering at the larger heading size (or, after an intermediate pass, smaller than everything else). No explicit type overrides remain on `.chat-header-title`.

## Testing
- Formatted with Prettier. Project ESLint/`vue-cli-service` couldn't run here (dev dependencies aren't installed in this environment); the SFC parses and has no remaining active references to the disabled code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkRKtAGbHpTkyuQ3JyvJSS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MkRKtAGbHpTkyuQ3JyvJSS)_