### PR TITLE
Restore full-width prose measure; return subscribe form to footer

### DIFF
--- a/src/components/MainFooter.vue
+++ b/src/components/MainFooter.vue
@@ -33,9 +33,10 @@
                 title="Jacques Ramphal"
                 description="I'm a designer working where design, code, and AI meet."
               />
-              <!-- Footer subscribe form hidden — the subscribe bar now sits
-                   above the footer (App.vue). Flip v-if to re-enable. -->
-              <div class="footer-subscribe" v-if="false">
+              <div class="footer-subscribe">
+                <p class="footer-subscribe__pitch">
+                  New essays on design, systems, and AI as I publish them. No noise.
+                </p>
                 <SubscribeForm />
               </div>
             </div>
@@ -481,6 +482,10 @@ li {
   .subtle {
     margin-block-end: var(--spacing-xxs);
   }
+}
+
+.footer-subscribe__pitch {
+  margin-block-end: var(--spacing-xs);
 }
 #content {
   grid-template-columns: repeat(2, 1fr);

--- a/src/components/text/MarkdownRenderer.vue
+++ b/src/components/text/MarkdownRenderer.vue
@@ -945,21 +945,6 @@ export default {
     }
   }
 
-  /* Readable measure — cap prose line length (~64ch) so wide viewports don't
-     produce unreadably long lines. Media-bearing paragraphs, code, tables, and
-     the poster h1 are intentionally left full-width. No effect on mobile, where
-     the viewport is narrower than the cap. */
-  p:not(:has(img)),
-  li,
-  blockquote,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    max-width: var(--size-36);
-  }
-
   a {
     color: var(--color-action);
     font-weight: var(--fontWeight-medium);


### PR DESCRIPTION
## What changed

Two small, independent UI fixes:

### 1. Markdown pages — remove the prose measure cap
`MarkdownRenderer.vue` had a `max-width: var(--size-36)` (~64rem / 640px) cap applied to paragraphs, list items, blockquotes, and `h2`–`h6` (added in `7ad3e53`). On wide viewports this narrowed the reading column to ~640px, which read as an unintended constraint on doc/markdown pages (e.g. `/doc/*`). This PR removes **only** the measure cap. The other two readability tweaks from that commit — `--lineHeight-body: 1.6` and the body-contrast bump — are intentionally kept.

### 2. Footer — bring the subscribe block back
The footer's subscribe form had been parked behind `v-if="false"` when the subscribe bar was temporarily moved above the footer (then itself parked in `App.vue` for a mobile-overflow issue). This restores it:
- The name + description `TextBlock` is unchanged.
- The `.footer-subscribe` block renders again (`SubscribeForm` was already imported/registered).
- The newsletter pitch sentence — *"New essays on design, systems, and AI as I publish them. No noise."* — sits above the email input, reusing the existing brand copy from `ArticleOutro`.

## Why
The narrow reading column and the missing footer subscribe field were both regressions the site owner wanted reverted.

## Reviewer notes
- The above-footer subscribe bar in `App.vue` stays **parked** on purpose — re-enabling it alongside the footer form would put two identical Buttondown forms on every article page.
- The footer form is a simpler single-column layout than the parked bar, but the original parking reason was **mobile overflow** — worth a quick check of the footer subscribe input at ≤767px.
- `design-guard` warnings on these files are pre-existing (hardcoded lengths) and WARNING-ONLY; no new violations were introduced — new spacing uses `var(--spacing-*)` tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)